### PR TITLE
Added method addMoreFrames

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,14 @@ This method stops playing the image sequence.
 sequence.stop();
 ```
 
+### addMoreFrames(moreFrames: number)
+
+This method adds more frames to the image sequence.
+
+```typescript
+sequence.addMoreFrames(moreFrames);
+```
+
 ### playing
 
 This getter method returns a boolean indicating whether the image sequence is playing.
@@ -282,7 +290,7 @@ tarball and implement the `imageURL` to return the URL of an image in the tarbal
 ### How can I create a tar file (tarball) with images?
 
 I created an easy-to-use online tool for this: [Tar File Creator](https://reindernijhoff.net/tools/tar/). Drag and drop your selection of images onto the page, and a tar file will be generated that you can download.
-You can also use a tar tool to create the tar file yourself. 
+You can also use a tar tool to create the tar file yourself.
 
 ### I want to download just 8 frames first and preload the rest of the images later. How can I do this?
 
@@ -322,7 +330,7 @@ const sequence = new FastImageSequence(containerElement, options);
 
 ### Can I download a tar file myself and use it with FastImageSequence?
 
-Yes, you can download the tar file yourself and create a data URL from it. You can then use this data URL as the `tarURL` option. 
+Yes, you can download the tar file yourself and create a data URL from it. You can then use this data URL as the `tarURL` option.
 See this [example](https://github.com/mediamonks/fast-image-sequence/blob/main/example/src/exampleLoadTar.js) for more information.
 
 


### PR DESCRIPTION
Issue: https://github.com/mediamonks/fast-image-sequence/issues/38

Fast Image Sequence Renderer, as it stands, is difficult to add frames to once initialized. It requires reinitialization to add more frames, which is inefficient and complicates the code since new images keep coming in over a short period, characteristic of streaming.

So, I have added the`addMoreFrames` method.

When `addMoreFrames` is called while the image sequence is running after the instance has been created, the frames and sources are restructured, allowing images to be added seamlessly.

To implement this, I moved some of the initialization logic from the constructor into a `struct` method. By calling `struct` in the `constructor`, it retains the same logic as before.

In `addMoreFrames`, after modifying `this.options.frames`, the `struct` method is called, followed by the `destruct` method to temporarily release resources like the canvas. Then, the original logic is executed with a few branching points. For example, when calling `drawingLoop`, it resumes from the previous playback point.

As a result, when the image sequence needs to grow continuously like streaming, calling the `addMoreFrames` method allows it to function like video streaming.